### PR TITLE
silence `unpack_mht`: suppress output of read_lines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # inbospatial 0.0.4
 
+## Bug fixes
+
+* A parameter setting in the `unpack_mht(path)` function of `get_coverage_wcs.R` produced unwanted empty line/linebreak output, which is now suppressed.
+
 # inbospatial 0.0.3
 
 ## Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 ## Bug fixes
 
-* A parameter setting in the `unpack_mht(path)` function of `get_coverage_wcs.R` produced unwanted empty line/linebreak output, which is now suppressed.
+* A parameter setting in the `unpack_mht(path)` function 
+  of `get_coverage_wcs.R` produced unwanted empty line/linebreak output, 
+  which is now suppressed.
 
 # inbospatial 0.0.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 
 * A parameter setting in the `unpack_mht(path)` function 
-  of `get_coverage_wcs.R` produced unwanted empty line/linebreak output, 
+  of `get_coverage_wcs.R` produced unwanted empty line break output, 
   which is now suppressed.
 
 # inbospatial 0.0.3

--- a/R/get_coverage_wcs.R
+++ b/R/get_coverage_wcs.R
@@ -219,19 +219,19 @@ get_coverage_wcs <- function(
 #' possibly a bug or edge case in `write_lines()`
 #' Therefore, also `read_file_raw()` needed to extract from the raw vector
 unpack_mht <- function(path) {
-  lines_raw <- read_lines_raw(path)
-  lines_char <- suppressWarnings(read_lines(path))
-  raw_vector <- read_file_raw(path)
+  lines_raw <- readr::read_lines_raw(path)
+  lines_char <- suppressWarnings(readr::read_lines(path, progress = FALSE))
+  raw_vector <- readr::read_file_raw(path)
 
-  assert_that(any(str_detect(lines_char, "image/tiff")))
-  start <- which(str_detect(lines_char, "^(II|MM)\\*"))
+  assertthat::assert_that(any(stringr::str_detect(lines_char, "image/tiff")))
+  start <- which(stringr::str_detect(lines_char, "^(II|MM)\\*"))
   end <- length(lines_raw) - 1
   pos_start <- length(unlist(lines_raw[1:(start - 1)])) + start
   pos_end <- length(raw_vector) - (length(lines_raw[end + 1]) + 1)
 
   tif <- raw_vector[pos_start:pos_end]
-  tif_path <- str_replace(path, "mht", "tif")
-  write_file(
+  tif_path <- stringr::str_replace(path, "mht", "tif")
+  readr::write_file(
     tif,
     tif_path
   )

--- a/R/get_feature_wfs.R
+++ b/R/get_feature_wfs.R
@@ -6,7 +6,7 @@
 #' The request is made up of key-value pairs and additional key-value pairs can
 #' be passed to the function.
 #' The full documentation for the `WFS` standard can be consulted from
-#' \url{https://www.ogc.org/publications/standard/wfs/}.
+#' \url{https://www.ogc.org/standard/wfs/}.
 #'
 #' @param wfs Web address for the service which you want to query features from
 #' @param version Version number for the service.
@@ -18,7 +18,7 @@
 #' Pass this as a named vector with names `"xmin"`, `"xmax"`, `"ymin"`,
 #' `"ymax"`.
 #' @param filter Optional
-#' [standard OGC filter](https://www.ogc.org/publications/standard/filter/)
+#' [standard OGC filter](https://www.ogc.org/standard/filter/)
 #' specification
 #' @param cql_filter Optional
 #' [Contextual Query Language](https://portal.ogc.org/files/96288) filter.

--- a/R/get_feature_wfs.R
+++ b/R/get_feature_wfs.R
@@ -6,7 +6,7 @@
 #' The request is made up of key-value pairs and additional key-value pairs can
 #' be passed to the function.
 #' The full documentation for the `WFS` standard can be consulted from
-#' \url{https://www.ogc.org/standard/wfs/}.
+#' \url{https://www.ogc.org/standards/wfs/}.
 #'
 #' @param wfs Web address for the service which you want to query features from
 #' @param version Version number for the service.
@@ -18,7 +18,7 @@
 #' Pass this as a named vector with names `"xmin"`, `"xmax"`, `"ymin"`,
 #' `"ymax"`.
 #' @param filter Optional
-#' [standard OGC filter](https://www.ogc.org/standard/filter/)
+#' [standard OGC filter](https://www.ogc.org/standards/filter/)
 #' specification
 #' @param cql_filter Optional
 #' [Contextual Query Language](https://portal.ogc.org/files/96288) filter.

--- a/checklist.yml
+++ b/checklist.yml
@@ -2,9 +2,8 @@ description: Configuration file for checklist::check_pkg()
 package: yes
 allowed:
   warnings:
-  - motivation: documentation is a good thing
-    value: 'documented but unexported functions: coneconst_lcc, inbospatial, inbospatial-package,
-      require_pkgs, unpack_mht'
+  - motivation: documentation is ok, even if not exported
+    value: 'documented but unexported functions: coneconst_lcc, require_pkgs, unpack_mht'
   notes:
   - motivation: will not be submitted to CRAN
     value: |-

--- a/man/get_feature_wfs.Rd
+++ b/man/get_feature_wfs.Rd
@@ -34,7 +34,7 @@ Pass this as a named vector with names \code{"xmin"}, \code{"xmax"}, \code{"ymin
 \code{"ymax"}.}
 
 \item{filter}{Optional
-\href{https://www.ogc.org/publications/standard/filter/}{standard OGC filter}
+\href{https://www.ogc.org/standards/filter/}{standard OGC filter}
 specification}
 
 \item{cql_filter}{Optional
@@ -63,7 +63,7 @@ features that are requested.
 The request is made up of key-value pairs and additional key-value pairs can
 be passed to the function.
 The full documentation for the \code{WFS} standard can be consulted from
-\url{https://www.ogc.org/publications/standard/wfs/}.
+\url{https://www.ogc.org/standards/wfs/}.
 }
 \details{
 See

--- a/vignettes/spatial_dhmv_query.Rmd
+++ b/vignettes/spatial_dhmv_query.Rmd
@@ -63,9 +63,6 @@ First, we need to load some packages.
 library("httr")
 library("sf")
 library("terra")
-# if (!requireNamespace("ows4R", quietly = TRUE)) {
-#   install.packages("ows4R")
-# }
 library("ows4R")
 ```
 
@@ -398,7 +395,7 @@ unpack_mht <- function(path) {
     tif,
     tif_path
   )
-  return(tif_path)
+  tif_path
 }
 ```
 

--- a/vignettes/spatial_dhmv_query.Rmd
+++ b/vignettes/spatial_dhmv_query.Rmd
@@ -63,16 +63,16 @@ First, we need to load some packages.
 library("httr")
 library("sf")
 library("terra")
-if (!requireNamespace("ows4R", quietly = TRUE)) {
-  install.packages("ows4R")
-}
+# if (!requireNamespace("ows4R", quietly = TRUE)) {
+#   install.packages("ows4R")
+# }
 library("ows4R")
 ```
 
 We can connect a WCS client.
 
 ```{r}
-wcs <- WCSClient$new(
+wcs <- ows4R::WCSClient$new(
   "https://geo.api.vlaanderen.be/DHMV/wcs", "2.0.1",
   logger = "INFO"
 )
@@ -129,7 +129,7 @@ x_test <- 148600
 y_test <- 208900
 range_m <- 2 # (+/- m)
 
-hopo_boxed <- OWSUtils$toBBOX(
+hopo_boxed <- ows4R::OWSUtils$toBBOX(
   xmin = x_test - range_m,
   xmax = x_test + range_m,
   ymin = y_test - range_m,
@@ -192,7 +192,7 @@ Well, there is advanced software to open GeoTIFF'esque files. Or geography marku
 
 First, if R failed, Python might work.
 
-```
+```{python}
 import rasterio
 import rasterio.plot
 
@@ -344,7 +344,7 @@ Your browser might detect that the file is an `mht`, or not.
 Here is an example of how to build a query with the current version of DHMV:
 
 ```{r}
-url <- parse_url("https://geo.api.vlaanderen.be/DHMV/wcs")
+url <- httr::parse_url("https://geo.api.vlaanderen.be/DHMV/wcs")
 
 # the query parameters which worked in QGIS
 url$query <- list(
@@ -360,7 +360,7 @@ url$query <- list(
   RESPONSE_CRS = "EPSG:31370"
 )
 
-request <- build_url(url)
+request <- httr::build_url(url)
 
 
 # get wcs data
@@ -369,7 +369,7 @@ mht_file <- tempfile(fileext = ".mht")
 print(request)
 print(mht_file)
 
-response <- GET(
+response <- httr::GET(
   url = request,
   write_disk(mht_file)
 )
@@ -381,19 +381,20 @@ With the `mht` specifications [found online](https://docs.fileformat.com/web/mht
 library("readr")
 library("stringr")
 
-unpack_mht <- function(mht_filepath) {
-  lines_raw <- read_lines_raw(mht_filepath)
-  lines_char <- suppressWarnings(read_lines(mht_filepath))
-  raw_vector <- read_file_raw(mht_filepath)
+unpack_mht <- function(path) {
+  lines_raw <- readr::read_lines_raw(path)
+  lines_char <- suppressWarnings(readr::read_lines(path, progress = FALSE))
+  raw_vector <- readr::read_file_raw(path)
 
-  start <- which(str_detect(lines_char, "^II\\*"))
+  assertthat::assert_that(any(stringr::str_detect(lines_char, "image/tiff")))
+  start <- which(stringr::str_detect(lines_char, "^(II|MM)\\*"))
   end <- length(lines_raw) - 1
   pos_start <- length(unlist(lines_raw[1:(start - 1)])) + start
   pos_end <- length(raw_vector) - (length(lines_raw[end + 1]) + 1)
 
   tif <- raw_vector[pos_start:pos_end]
-  tif_path <- str_replace(mht_filepath, "mht", "tif")
-  write_file(
+  tif_path <- stringr::str_replace(path, "mht", "tif")
+  readr::write_file(
     tif,
     tif_path
   )
@@ -406,7 +407,7 @@ This way you get the elevation data extracted:
 
 ```{r}
 tif_file <- unpack_mht(mht_file)
-raster <- rast(tif_file)
+raster <- terra::rast(tif_file)
 plot(raster, col = gray.colors(256))
 ```
 

--- a/vignettes/spatial_dhmv_query.Rmd
+++ b/vignettes/spatial_dhmv_query.Rmd
@@ -189,7 +189,7 @@ Well, there is advanced software to open GeoTIFF'esque files. Or geography marku
 
 First, if R failed, Python might work.
 
-```{python}
+```
 import rasterio
 import rasterio.plot
 


### PR DESCRIPTION
suppression of progress in the `unpack_mht(path)` function of `get_coverage_wcs.R`, which would otherwise produce empty stdout via `readr::read_lines(path)` progress.

fixes https://github.com/inbo/inbospatial/issues/18


*(as an aside, I inserted explicit library calls such as `readr::read_lines_raw` which simplifies debugging on my system and increases portability potential of `unpack_mht`.)*